### PR TITLE
Roles: first draft

### DIFF
--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -49,7 +49,8 @@ There are sub-roles within the core team depending on the kinds covering differe
 ### Core developers
 
 Core developers are members of the core team who have made signifigant code contributions to `scverse`.
-Becoming a core developer allows contributors to merge approved pull requests, cast votes for and against merging a pull-request, and be involved in deciding major changes to the API, and thereby more easily carry on with their project related activities. 
+They are granted additional rights so they can more easily carry on with their `scverse` related activities.
+These rights include: merging approved pull requests, voting for and against contested pull-requests, and being involved in deciding major changes to the API.
 Core developers are on our [@scverse/core-devs](https://github.com/orgs/scverse/teams/core-devs) GitHub team (**TODO**).
 Core developers are expected to review code contributions while adhering to the [core developer guide](CORE_DEV_GUIDE.md) (**TODO**).
 

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -41,7 +41,7 @@ This includes who gets commit rights to their projects.
 ## Core team
 
 The core team are community members that have demonstrated continued commitment to the project through ongoing contributions.
-They have shown they can be trusted to maintain the scverse with care.
+They have shown they can be trusted to maintain scverse with care.
 Team members appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@scverse/core](https://github.com/orgs/scverse/teams/core) GitHub team (**TODO**).
 
 There are sub-roles within the core team depending on the kinds covering different kinds of contributions and responsibilities.

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -57,7 +57,7 @@ All core packages must have at least one core developer as a maintainer.
 New core developers can be nominated by any existing core developer. 
 While there is no hard-and-fast rule about who can be nominated, ideally, they should have: 
 
-* Been part of the community for at least two months
+* Been part of the community for a significant amount of time
 * Contributed significant changes of their own
 * Contributed to the discussion and review of others' work
 * Collaborated in a way befitting our community values

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -48,7 +48,7 @@ There are sub-roles within the core team depending on the kinds covering differe
 
 ### Core developers
 
-Core developers are members of the core team who have made signifigant code contributions to the `scverse`.
+Core developers are members of the core team who have made signifigant code contributions to `scverse`.
 Becoming a core developer allows contributors to merge approved pull requests, cast votes for and against merging a pull-request, and be involved in deciding major changes to the API, and thereby more easily carry on with their project related activities. 
 Core developers are on our [@scverse/core-devs](https://github.com/orgs/scverse/teams/core-devs) GitHub team (**TODO**).
 Core developers are expected to review code contributions while adhering to the [core developer guide](CORE_DEV_GUIDE.md) (**TODO**).

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -1,0 +1,125 @@
+# Abstract
+
+The purpose of this document is to formalize the governance process used by the `scverse` project, to clarify how decisions are made and how the various elements of our community interact.
+
+As a whole, we are a consensus-based community project.
+However, any subproject within the scverse can have their own governance system as long as they do not conflict with the rules set out here.
+Anyone with an interest in the project can join the community, contribute to the project design, and participate in the decision making process.
+This document describes how that participation takes place, how to find consensus, and how deadlocks are resolved.
+
+# Roles And Responsibilities
+
+## The Community
+
+The scverse community consists of anyone using or working with the project in any way.
+
+## Contributors
+
+A community member can become a contributor by interacting directly with the project in concrete ways, such as:
+
+- proposing, discussing, or reviewing a change to the code, documentation, or specification via a GitHub pull request to any https://github.com/scverse repository;
+- reporting a GitHub issue to any https://github.com/scverse repository;
+- discussing examples or usage issues on any of our discussion platforms
+
+among other possibilities.
+Any community member can become a contributor, and all are encouraged to do so.
+By contributing to the project, community members can directly help to shape its future.
+
+Potential contributors are encouraged to read the Contributing Guide (**TODO**) as well as the Code of Conduct (**TODO**)
+
+A community member becomes a contributor when the following criteria are met:
+
+- At least two core developers from separate employers agree membership is a good idea.
+- The new member has supported the project several times, either through code or otherwise, and has demonstrated a willingness to help solve other people's problems, not just their own.
+- The new member demonstrates some degree of familiarity of open source practices and online courtesy.
+
+## Core developers
+
+Core developers are community members that have demonstrated continued commitment to the project through ongoing contributions.
+They have shown they can be trusted to maintain the scverse with care.
+Becoming a core developer allows contributors to merge approved pull requests, cast votes for and against merging a pull-request, and be involved in deciding major changes to the API, and thereby more easily carry on with their project related activities. 
+Core developers appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team (**TODO**).
+Core developers are expected to review code contributions while adhering to the [core developer guide](CORE_DEV_GUIDE.md) (**TODO**).
+New core developers can be nominated by any existing core developer, and for details on that process see our core developer guide.
+
+## Steering Council
+
+The Steering Council (SC) members are core developers who have additional responsibilities to ensure the smooth running of the project.
+SC members are expected to participate in strategic planning, approve changes to the governance model, and make decisions about funding granted to the project itself.
+(Funding to community members is theirs to pursue and manage). 
+The purpose of the SC is to ensure smooth progress from the big-picture perspective.
+Changes that impact the full project require analysis informed by long experience with both the project and the larger ecosystem.
+When the core developer community (including the SC members) fails to reach such a consensus in a reasonable timeframe, the SC is the entity that resolves the issue.
+
+Members of the steering council also have the "owner" (**TBD**) role within the [zarr-developers GitHub organization](https://github.com/zarr-developers/)
+and are ultimately responsible for managing the [scverse](https://github.com/scverse) GitHub account, the [@zarr_dev](https://twitter.com/zarr_dev)
+twitter account, the [scverse website](https://scverse.org), and other similar scverse-owned resources.
+
+The steering council is currently fixed in size to three members.
+This number may be increased in the future, but will always be an odd number to ensure a simple majority vote outcome is always possible. 
+The initial steering council of Zarr consists of
+
+* [Ryan Abernathey](https://github.com/rabernat)
+
+* [John Kirkham](https://github.com/jakirkham)
+
+* [Alistair Miles](https://github.com/alimanfoo)
+
+* [Josh Moore](https://github.com/joshmoore)
+
+* [Ryan Williams](https://github.com/ryan-williams)
+
+The SC membership is revisited every January.
+SC members who do not actively engage with the SC duties are expected to resign.
+New members are added by nomination by a core developer.
+Nominees should have demonstrated long-term, continued commitment to the project and its mission and values.
+A nomination will result in discussion that cannot take more than a month and then admission to the SC by consensus.
+During that time deadlocked votes of the SC will be postponed until the new member has joined and another vote can be held.
+
+The Zarr steering council may be contacted at `zarr-steering-council@googlegroups.com`, or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team. (**TODO**)
+
+# Decision Making Process
+
+Decisions about the future of the project are made through discussion with all members of the community.
+All non-sensitive project management discussion takes place on the issue trackers of the https://github.com/scverse repositories.
+Occasionally, sensitive discussion may occur via a private message.
+
+Decisions should be made in accordance with the mission and values of the scverse project.
+
+scverse uses a “consensus seeking” process for making decisions.
+The group tries to find a resolution that has no open objections among core developers.
+Core developers are expected to distinguish between fundamental objections to a proposal and minor perceived flaws that they can live with, and not hold up the decision-making process for the latter.
+If no option can be found without objections, the decision is escalated to the SC, which will itself use consensus seeking to come to a resolution.
+In the unlikely event that there is still a deadlock, the proposal will move forward if it has the support of a simple majority of the SC.
+
+Decisions (in addition to adding core developers and SC membership as above) are made according to the following rules:
+
+- **Minor documentation changes**, such as typo fixes, or addition / correction of a
+  sentence, require approval by a core developer *and* no disagreement or requested
+  changes by a core developer on the issue or pull request page (lazy
+  consensus). Core developers are expected to give "reasonable time" after approval and before merging for others
+  to give their opinion on the pull request if they’re not confident others
+  would agree, where "reasonable time" is likely one working day.
+
+- **Code changes and major documentation changes** require agreement by *one*
+  core developer *and* no disagreement or requested changes by a core developer
+  on the issue or pull-request page (lazy consensus). For all changes of this type,
+  core developers are expected to give "reasonable time" after approval and before
+  merging for others to weigh in on the pull request in its final state, where
+  "reasonable time" is likely a few working days.
+
+- **Changes to APIs** require a dedicated issue on the related
+  issue tracker, e.g. [muon](https://github.com/scverse/muon/issues), and follow the
+  decision-making process outlined above, though "reasonable time" is likely extended
+  to at least a week.
+
+- **Changes to the specification** require a dedicated issue on the [issue tracker](https://github.com/zarr-developers/zarr-specs/issues) and even more time than an API change.
+  The appropriate length of time is currently under discussion.
+
+- **Changes to this governance model or our mission, vision, and values**
+  require a  dedicated issue on our [issue tracker](https://github.com/zarr-developers/governance/issues)
+  and follow the decision-making process outlined above, with "reasonable time" being
+  at least two weeks. However, if there is unanimous agreement from core developers on the change,
+  it can move forward faster.
+
+If an objection is raised on a lazy consensus, the proposer can appeal to the community and core developers and the change can be approved or rejected by escalating to the SC.

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -86,34 +86,4 @@ Core developers are expected to distinguish between fundamental objections to a 
 If no option can be found without objections, the decision is escalated to the SC, which will itself use consensus seeking to come to a resolution.
 In the unlikely event that there is still a deadlock, the proposal will move forward if it has the support of a simple majority of the SC.
 
-Decisions (in addition to adding core developers and SC membership as above) are made according to the following rules:
-
-- **Minor documentation changes**, such as typo fixes, or addition / correction of a
-  sentence, require approval by a core developer *and* no disagreement or requested
-  changes by a core developer on the issue or pull request page (lazy
-  consensus). Core developers are expected to give "reasonable time" after approval and before merging for others
-  to give their opinion on the pull request if they’re not confident others
-  would agree, where "reasonable time" is likely one working day.
-
-- **Code changes and major documentation changes** require agreement by *one*
-  core developer *and* no disagreement or requested changes by a core developer
-  on the issue or pull-request page (lazy consensus). For all changes of this type,
-  core developers are expected to give "reasonable time" after approval and before
-  merging for others to weigh in on the pull request in its final state, where
-  "reasonable time" is likely a few working days.
-
-- **Changes to APIs** require a dedicated issue on the related
-  issue tracker, e.g. [muon](https://github.com/scverse/muon/issues), and follow the
-  decision-making process outlined above, though "reasonable time" is likely extended
-  to at least a week.
-
-- **Changes to the specification** require a dedicated issue on the [issue tracker](https://github.com/zarr-developers/zarr-specs/issues) and even more time than an API change.
-  The appropriate length of time is currently under discussion.
-
-- **Changes to this governance model or our mission, vision, and values**
-  require a  dedicated issue on our [issue tracker](https://github.com/zarr-developers/governance/issues)
-  and follow the decision-making process outlined above, with "reasonable time" being
-  at least two weeks. However, if there is unanimous agreement from core developers on the change,
-  it can move forward faster.
-
 If an objection is raised on a lazy consensus, the proposer can appeal to the community and core developers and the change can be approved or rejected by escalating to the SC.

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -33,12 +33,19 @@ A community member becomes a contributor when the following criteria are met:
 - At least two core developers from separate employers agree membership is a good idea.
 - The new member has supported the project several times, either through code or otherwise, and has demonstrated a willingness to help solve other people's problems, not just their own.
 
-## Core developers
+## Core team
 
-Core developers are community members that have demonstrated continued commitment to the project through ongoing contributions.
+The core team are community members that have demonstrated continued commitment to the project through ongoing contributions.
 They have shown they can be trusted to maintain the scverse with care.
+Team members appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@scverse/core](https://github.com/orgs/scverse/teams/core) GitHub team (**TODO**).
+
+There are sub-roles within the core team depending on the kinds covering different kinds of contributions and responsibilities.
+
+### Core developers
+
+Core developers are members of the core team who have made signifigant code contributions to the `scverse`.
 Becoming a core developer allows contributors to merge approved pull requests, cast votes for and against merging a pull-request, and be involved in deciding major changes to the API, and thereby more easily carry on with their project related activities. 
-Core developers appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@scverse/core-devs](https://github.com/orgs/scverse/teams/core-devs) GitHub team (**TODO**).
+Core developers are on our [@scverse/core-devs](https://github.com/orgs/scverse/teams/core-devs) GitHub team (**TODO**).
 Core developers are expected to review code contributions while adhering to the [core developer guide](CORE_DEV_GUIDE.md) (**TODO**).
 New core developers can be nominated by any existing core developer, and for details on that process see our core developer guide.
 All core packages must have at least one core developer as a maintainer.

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -47,8 +47,19 @@ Core developers are members of the core team who have made signifigant code cont
 Becoming a core developer allows contributors to merge approved pull requests, cast votes for and against merging a pull-request, and be involved in deciding major changes to the API, and thereby more easily carry on with their project related activities. 
 Core developers are on our [@scverse/core-devs](https://github.com/orgs/scverse/teams/core-devs) GitHub team (**TODO**).
 Core developers are expected to review code contributions while adhering to the [core developer guide](CORE_DEV_GUIDE.md) (**TODO**).
-New core developers can be nominated by any existing core developer, and for details on that process see our core developer guide.
+
 All core packages must have at least one core developer as a maintainer.
+New core developers can be nominated by any existing core developer. 
+While there is no hard-and-fast rule about who can be nominated, ideally, they should have: 
+
+* Been part of the community for at least two months
+* Contributed significant changes of their own
+* Contributed to the discussion and review of others' work
+* Collaborated in a way befitting our community values
+
+After nomination voting will happen on a private mailing list by the core team.
+While it is expected that most votes will be unanimous, a two-thirds majority of the cast votes is enough.
+
 Primary maintainers of new core packages, who are not already core developers, will be invited to join.
 
 ## Steering Council

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -70,7 +70,7 @@ Primary maintainers of new core packages, who are not already core developers, w
 ## Steering Council
 
 The Steering Council (SC) members are core developers who have additional responsibilities to ensure the smooth running of the project.
-SC members are expected to participate in strategic planning, approve changes to the governance model, and make decisions about funding granted to the project itself.
+SC members are expected to participate in strategic planning, approve changes to the governance model, and make decisions about funding granted to `scverse` itself.
 (Funding to community members is theirs to pursue and manage). 
 The purpose of the SC is to ensure smooth progress from the big-picture perspective.
 Changes that impact the full project require analysis informed by long experience with both the project and the larger ecosystem.

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -35,7 +35,7 @@ A community member becomes a contributor when the following criteria are met:
 
 ### Project developers
 
-Individual projects within the scverse have a lot of freedom in deciding how their projects are developed.
+Individual projects within scverse have a lot of freedom in deciding how their projects are developed.
 This includes who gets commit rights to their projects.
 
 ## Core team

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -61,7 +61,7 @@ The initial steering council of the `scverse` consists of
 
 * [Isaac Virshup](https://github.com/ivirshup)
 * [Danila Bredikhin](https://github.com/gtca)
-* [Lukas Huemos](https://github.com/Zethson)
+* [Lukas Heumos](https://github.com/Zethson)
 
 The SC membership is revisited every January.
 SC members who do not actively engage with the SC duties are expected to resign.

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -13,7 +13,7 @@ This document describes how that participation takes place, how to find consensu
 
 The scverse community consists of anyone using or working with the project in any way.
 
-## Contributors/ Project developers
+## Contributors
 
 A community member can become a contributor by interacting directly with the project in concrete ways, such as:
 
@@ -32,6 +32,11 @@ A community member becomes a contributor when the following criteria are met:
 
 - At least two core developers from separate employers agree membership is a good idea.
 - The new member has supported the project several times, either through code or otherwise
+
+### Project developers
+
+Individual projects within the scverse have a lot of freedom in deciding how their projects are developed.
+This includes who gets commit rights to their projects.
 
 ## Core team
 

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -41,6 +41,8 @@ Becoming a core developer allows contributors to merge approved pull requests, c
 Core developers appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team (**TODO**).
 Core developers are expected to review code contributions while adhering to the [core developer guide](CORE_DEV_GUIDE.md) (**TODO**).
 New core developers can be nominated by any existing core developer, and for details on that process see our core developer guide.
+All core packages must have at least one core developer as a maintainer.
+Primary maintainers of new core packages, who are not already core developers, will be invited to join.
 
 ## Steering Council
 

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -42,7 +42,7 @@ This includes who gets commit rights to their projects.
 
 The core team are community members that have demonstrated continued commitment to the project through ongoing contributions.
 They have shown they can be trusted to maintain scverse with care.
-Team members appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@scverse/core](https://github.com/orgs/scverse/teams/core) GitHub team (**TODO**).
+Team members appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@scverse/core](https://github.com/orgs/scverse/teams/core) GitHub team.
 
 There are sub-roles within the core team depending on the kinds covering different kinds of contributions and responsibilities.
 
@@ -69,14 +69,14 @@ Primary maintainers of new core packages, who are not already core developers, w
 
 ## Steering Council
 
-The Steering Council (SC) members are core developers who have additional responsibilities to ensure the smooth running of the project.
+The Steering Council (SC) members are core team members who have additional responsibilities to ensure the smooth running of the project.
 SC members are expected to participate in strategic planning, approve changes to the governance model, and make decisions about funding granted to `scverse` itself.
 (Funding to community members is theirs to pursue and manage). 
 The purpose of the SC is to ensure smooth progress from the big-picture perspective.
 Changes that impact the full project require analysis informed by long experience with both the project and the larger ecosystem.
-When the core developer community (including the SC members) fails to reach such a consensus in a reasonable timeframe, the SC is the entity that resolves the issue.
+When the core team (including the SC members) fails to reach such a consensus in a reasonable timeframe, the SC is the entity that resolves the issue.
 
-Members of the steering council also have the "owner" (**TBD**) role within the [scverse GitHub organization](https://github.com/scverse/)
+Members of the steering council also have the "owner" role within the [scverse GitHub organization](https://github.com/scverse/)
 and are ultimately responsible for managing the [scverse](https://github.com/scverse) GitHub account, the [@scverse](https://twitter.com/scanpy_team)
 twitter account, the [scverse website](https://scverse.org), and other similar scverse-owned resources.
 
@@ -99,8 +99,8 @@ The `scverse` steering council may be contacted at `steering-council@scverse.org
 
 # Decision Making Process
 
-Decisions about the future of the project are made through discussion with all members of the community.
-All non-sensitive project management discussion takes place on the issue trackers of the https://github.com/scverse repositories.
+Decisions about the future of the project are made through discussion with members of the community.
+All non-sensitive project management discussion takes place on the issue trackers of the https://github.com/scverse repositories, in public channels of our chat, or on the forums.
 Occasionally, sensitive discussion may occur via a private message.
 
 Decisions should be made in accordance with the mission and values of the scverse project.

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -13,7 +13,7 @@ This document describes how that participation takes place, how to find consensu
 
 The scverse community consists of anyone using or working with the project in any way.
 
-## Contributors
+## Contributors/ Project developers
 
 A community member can become a contributor by interacting directly with the project in concrete ways, such as:
 
@@ -32,14 +32,13 @@ A community member becomes a contributor when the following criteria are met:
 
 - At least two core developers from separate employers agree membership is a good idea.
 - The new member has supported the project several times, either through code or otherwise, and has demonstrated a willingness to help solve other people's problems, not just their own.
-- The new member demonstrates some degree of familiarity of open source practices and online courtesy.
 
 ## Core developers
 
 Core developers are community members that have demonstrated continued commitment to the project through ongoing contributions.
 They have shown they can be trusted to maintain the scverse with care.
 Becoming a core developer allows contributors to merge approved pull requests, cast votes for and against merging a pull-request, and be involved in deciding major changes to the API, and thereby more easily carry on with their project related activities. 
-Core developers appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@zarr-developers/core-devs](https://github.com/orgs/zarr-developers/teams/core-devs) GitHub team (**TODO**).
+Core developers appear as organization members on the scverse [GitHub organization](https://github.com/orgs/scverse/people) and are on our [@scverse/core-devs](https://github.com/orgs/scverse/teams/core-devs) GitHub team (**TODO**).
 Core developers are expected to review code contributions while adhering to the [core developer guide](CORE_DEV_GUIDE.md) (**TODO**).
 New core developers can be nominated by any existing core developer, and for details on that process see our core developer guide.
 All core packages must have at least one core developer as a maintainer.
@@ -54,8 +53,8 @@ The purpose of the SC is to ensure smooth progress from the big-picture perspect
 Changes that impact the full project require analysis informed by long experience with both the project and the larger ecosystem.
 When the core developer community (including the SC members) fails to reach such a consensus in a reasonable timeframe, the SC is the entity that resolves the issue.
 
-Members of the steering council also have the "owner" (**TBD**) role within the [zarr-developers GitHub organization](https://github.com/zarr-developers/)
-and are ultimately responsible for managing the [scverse](https://github.com/scverse) GitHub account, the [@zarr_dev](https://twitter.com/zarr_dev)
+Members of the steering council also have the "owner" (**TBD**) role within the [scverse GitHub organization](https://github.com/scverse/)
+and are ultimately responsible for managing the [scverse](https://github.com/scverse) GitHub account, the [@scverse](https://twitter.com/scanpy_team)
 twitter account, the [scverse website](https://scverse.org), and other similar scverse-owned resources.
 
 The steering council is currently fixed in size to three members.
@@ -73,7 +72,7 @@ Nominees should have demonstrated long-term, continued commitment to the project
 A nomination will result in discussion that cannot take more than a month and then admission to the SC by consensus.
 During that time deadlocked votes of the SC will be postponed until the new member has joined and another vote can be held.
 
-The `scverse` steering council may be contacted at `zarr-steering-council@googlegroups.com`, or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team. (**TODO**)
+The `scverse` steering council may be contacted at `steering-council@scverse.org`, or via the [@scverse/steering-council](https://github.com/orgs/scverse/teams/steering-council) GitHub team.
 
 # Decision Making Process
 

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -90,8 +90,8 @@ Occasionally, sensitive discussion may occur via a private message.
 Decisions should be made in accordance with the mission and values of the scverse project.
 
 scverse uses a “consensus seeking” process for making decisions.
-The group tries to find a resolution that has no open objections among core developers.
-Core developers are expected to distinguish between fundamental objections to a proposal and minor perceived flaws that they can live with, and not hold up the decision-making process for the latter.
+The group tries to find a resolution that has no open objections among relevant core team members.
+Core members are expected to distinguish between fundamental objections to a proposal and minor perceived flaws that they can live with, and not hold up the decision-making process for the latter.
 If no option can be found without objections, the decision is escalated to the SC, which will itself use consensus seeking to come to a resolution.
 In the unlikely event that there is still a deadlock, the proposal will move forward if it has the support of a simple majority of the SC.
 

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -63,8 +63,7 @@ While there is no hard-and-fast rule about who can be nominated, ideally, they s
 * Contributed to the discussion and review of others' work
 * Collaborated in a way befitting our community values
 
-After nomination voting will happen on a private mailing list by the core team.
-While it is expected that most votes will be unanimous, a two-thirds majority of the cast votes is enough.
+After nomination admission will be decided by two-thirds majority vote on a private mailing list by the core team.
 
 Primary maintainers of new core packages, who are not already core developers, will be invited to join.
 

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -31,7 +31,7 @@ Potential contributors are encouraged to read the Contributing Guide (**TODO: ad
 A community member becomes a contributor when the following criteria are met:
 
 - At least two core developers from separate employers agree membership is a good idea.
-- The new member has supported the project several times, either through code or otherwise, and has demonstrated a willingness to help solve other people's problems, not just their own.
+- The new member has supported the project several times, either through code or otherwise
 
 ## Core team
 

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -56,18 +56,12 @@ and are ultimately responsible for managing the [scverse](https://github.com/scv
 twitter account, the [scverse website](https://scverse.org), and other similar scverse-owned resources.
 
 The steering council is currently fixed in size to three members.
-This number may be increased in the future, but will always be an odd number to ensure a simple majority vote outcome is always possible. 
-The initial steering council of Zarr consists of
+This number will be increased as our community grows and diversifies, but will always be an odd number to ensure a simple majority vote outcome is always possible. 
+The initial steering council of the `scverse` consists of
 
-* [Ryan Abernathey](https://github.com/rabernat)
-
-* [John Kirkham](https://github.com/jakirkham)
-
-* [Alistair Miles](https://github.com/alimanfoo)
-
-* [Josh Moore](https://github.com/joshmoore)
-
-* [Ryan Williams](https://github.com/ryan-williams)
+* [Isaac Virshup](https://github.com/ivirshup)
+* [Danila Bredikhin](https://github.com/gtca)
+* [Lukas Huemos](https://github.com/Zethson)
 
 The SC membership is revisited every January.
 SC members who do not actively engage with the SC duties are expected to resign.
@@ -76,7 +70,7 @@ Nominees should have demonstrated long-term, continued commitment to the project
 A nomination will result in discussion that cannot take more than a month and then admission to the SC by consensus.
 During that time deadlocked votes of the SC will be postponed until the new member has joined and another vote can be held.
 
-The Zarr steering council may be contacted at `zarr-steering-council@googlegroups.com`, or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team. (**TODO**)
+The `scverse` steering council may be contacted at `zarr-steering-council@googlegroups.com`, or via the [@zarr-developers/steering-council](https://github.com/orgs/zarr-developers/teams/steering-council) GitHub team. (**TODO**)
 
 # Decision Making Process
 

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -30,7 +30,7 @@ Potential contributors are encouraged to read the Contributing Guide (**TODO: ad
 
 A community member becomes a contributor when the following criteria are met:
 
-- At least two core developers from separate employers agree membership is a good idea.
+- At least two core team members support their addition
 - The new member has supported the project several times, either through code or otherwise
 
 ### Project developers

--- a/in_progress/roles.md
+++ b/in_progress/roles.md
@@ -25,7 +25,8 @@ among other possibilities.
 Any community member can become a contributor, and all are encouraged to do so.
 By contributing to the project, community members can directly help to shape its future.
 
-Potential contributors are encouraged to read the Contributing Guide (**TODO**) as well as the Code of Conduct (**TODO**)
+All community members are required to adhere by our code of conduct (**TODO: add link**).
+Potential contributors are encouraged to read the Contributing Guide (**TODO: add link**).
 
 A community member becomes a contributor when the following criteria are met:
 


### PR DESCRIPTION
First stab at addressing #3, largely taken from the format that `zarr`, `scikit-learn`, `scikit-image`, and `napari` use.

## Location of this document

I've added this document to an `in_progress` directory. The idea here is that we can merge something in an early state and make changes via PRs. Once we have a final version of the document we can move it somewhere else.

## Some questions, changes that need to be made

Apart from `zarr`, the other projects that use this template don't have the "multiple subproject" composition that the scverse does. We may need to make changes accordingly.

### How do these roles apply to subprojects?

Who are the "core developers" and what rights do they get across the core projects?

### Do we have an official "contributors" role?

Do we have some level of team member who doesn't get commit rights to everything? Or is this just people who have made PRs?

I think it would be nice to have some form of recognition for these members of our community, but I'd like to figure out how we decide who can be added and what additional access they get if any.

### Decision making

Right now I'm in favor of removing a lot of the detail from the decision making process. Most anything that relates to specific kinds of PRs, since it's also good to be able to move quickly and around everyone's schedules.