### PR TITLE
Use checkout filters

### DIFF
--- a/developer/gpu_ci.md
+++ b/developer/gpu_ci.md
@@ -94,9 +94,9 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          filter: "tree:0"
 
       - name: Nvidia SMI sanity check
         run: nvidia-smi


### PR DESCRIPTION
See https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

This change has the intended effect (intact commit history) but without downloading every version of every file.