### PR TITLE
Revise onboarding checklist for new core team members

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-new-core-team-member.md
+++ b/.github/ISSUE_TEMPLATE/add-new-core-team-member.md
@@ -17,14 +17,15 @@ assignees: ""
 - [ ] add to Zulip
   - [ ] [core group](https://scverse.zulipchat.com/#groups/308955/core/members)
   - [ ] [core team private channel] (https://scverse.zulipchat.com/#narrow/channel/315186-core-team)
+  - [ ] [core developers' private channel](https://scverse.zulipchat.com/#narrow/channel/590174-core-developers), if relevant
 - [ ] add to [NumFOCUS Zulip](https://numfocus.zulipchat.com/)
 - [ ] add to the GitHub organization and [scverse/core](https://github.com/orgs/scverse/teams/core) GitHub team
-- [ ] add to the Notion workspace, if required
+- [ ] add to the Notion workspace
 - [ ] grant “[Leader](https://discourse.scverse.org/badges/4/leader)” trust level on Discourse
 
 ## onboarding
 
-- [ ] send link to the [core team handbook](https://docs.google.com/document/d/1VbmcPM5pivthVnDHH0UgX7zITQFIJyahDjI_WYu7xzE)
+- [ ] send link to the [core team handbook](https://app.notion.com/p/Core-Team-Handbook-3bc0c8e8129780ae8489c72a41c9f927?source=copy_link)
 - [ ] add to the [website core team member list](https://github.com/scverse/scverse.github.io/blob/main/content/people/_index.md)
 
 ## announcement

--- a/.github/ISSUE_TEMPLATE/add-new-core-team-member.md
+++ b/.github/ISSUE_TEMPLATE/add-new-core-team-member.md
@@ -8,14 +8,25 @@ assignees: ""
 
 # Onboarding checklist
 
-- [ ] add to [website core team member list](https://github.com/scverse/scverse.github.io/blob/main/content/people/_index.md)
-- [ ] add to core@scverse.org [google group](https://groups.google.com/u/1/g/scverse-core-team). Note: the email address used here will also get access to the shared google drive and calendars
-- [ ] add to zulip
-  - [ ] [zulip core group](https://scverse.zulipchat.com/#groups/308955/core/members)
-  - [ ] [core team private channel](https://docs.google.com/document/d/1VbmcPM5pivthVnDHH0UgX7zITQFIJyahDjI_WYu7xzE/edit#heading=h.6idmmugj38ay)
-- [ ] Grant “[Leader](https://discourse.scverse.org/badges/4/leader)” trust level on discourse
-- [ ] add to [password manager](https://scverse.1password.com/)
-- [ ] add to github org and [scverse/core](https://github.com/orgs/scverse/teams/core) github team
-- [ ] Add to [NumFOCUS slack](https://numfocus.slack.com/)
-- [ ] Send link to [core team handbook](https://docs.google.com/document/d/1VbmcPM5pivthVnDHH0UgX7zITQFIJyahDjI_WYu7xzE)
-- [ ] announce the new member on [scverse_team twitter](https://twitter.com/scverse_team/)
+## accounts & access
+
+- [ ] create a [Google Workspace account](https://admin.google.com/) with an @scverse.org domain email address
+- [ ] add to the [password manager](https://scverse.1password.com/)
+- [ ] add to the core@scverse.org [Google Group](https://groups.google.com/u/1/g/scverse-core-team)
+  - note: membership also grants access to the shared Google Drive and calendars
+- [ ] add to Zulip
+  - [ ] [core group](https://scverse.zulipchat.com/#groups/308955/core/members)
+  - [ ] [core team private channel] (https://scverse.zulipchat.com/#narrow/channel/315186-core-team)
+- [ ] add to [NumFOCUS Zulip](https://numfocus.zulipchat.com/)
+- [ ] add to the GitHub organization and [scverse/core](https://github.com/orgs/scverse/teams/core) GitHub team
+- [ ] add to the Notion workspace, if required
+- [ ] grant “[Leader](https://discourse.scverse.org/badges/4/leader)” trust level on Discourse
+
+## onboarding
+
+- [ ] send link to the [core team handbook](https://docs.google.com/document/d/1VbmcPM5pivthVnDHH0UgX7zITQFIJyahDjI_WYu7xzE)
+- [ ] add to the [website core team member list](https://github.com/scverse/scverse.github.io/blob/main/content/people/_index.md)
+
+## announcement
+
+- [ ] announce the new member on scverse social media channels


### PR DESCRIPTION
- Reorganized the checklist into sections: accounts & access, onboarding, and announcement 
- Reordered steps to follow their dependencies (e.g. creating the Google Workspace account before granting access)
- Added Google Workspace and optional Notion access
- Updated and consolidated existing access links and steps
- Updating inconsistent/outdated info (e.g. NF Slack -> NF Zulip)